### PR TITLE
Replaced last occurrence of obj_id with sbol_obj.identity.get() to avoid using obj_id be…

### DIFF
--- a/source/document.cpp
+++ b/source/document.cpp
@@ -2039,7 +2039,7 @@ void SBOLObject::update_uri()
     // Add to Document and check for uniqueness of URI
     if (parent.doc)
     {
-        vector<SBOLObject*> matches = parent.doc->find_property_value(SBOL_IDENTITY, obj_id);
+        vector<SBOLObject*> matches = parent.doc->find_property_value(SBOL_IDENTITY, sbol_obj.identity.get());
         if (matches.size() > 1)
             throw SBOLError(DUPLICATE_URI_ERROR, "Cannot update SBOL-compliant URI. An object with URI " + sbol_obj.identity.get() + " is already in the Document");
     }


### PR DESCRIPTION
Replaced last occurrence of obj_id with sbol_obj.identity.get() in document.cpp to avoid using obj_id before it has been declared in the update_uri method. This was causing my build to fail.